### PR TITLE
Remove Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install --upgrade codecov setuptools
+        pip install --upgrade setuptools
     - name: Install
       run: |
         python setup.py install
     - name: Run tests
       run: |
         cd tests
-        coverage run --source=metadata_updater tests.py
+        python -m unittest tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/linz/lds-metadata-updater/LICENSE) 
-[![codecov](https://codecov.io/gh/linz/lds-metadata-updater/branch/master/graph/badge.svg)](https://codecov.io/gh/linz/lds-metadata-updater)
 [![GitHub Actions Status](https://github.com/linz/lds-metadata-updater/workflows/CI/badge.svg)](https://github.com/linz/lds-metadata-updater/actions)
 
 


### PR DESCRIPTION
Removing Codecov due to a security incident where environment secrets were exposed to a third party for 2 months.